### PR TITLE
Ignore periods when splitting hours

### DIFF
--- a/openy_hours_formatter.module
+++ b/openy_hours_formatter.module
@@ -75,7 +75,7 @@ function openy_hours_formatter_tokens($type, $tokens, array $data, array $option
         if ($hours = $node->field_branch_hours->{'hours_'.$key}) {
           // Find a non-digit, non-word, non-whitespace character and split,
           // and automagically return the full string if no match.
-          $hours = preg_split('/\s?[^\d\s\w:]\s?/',$hours, -1, PREG_SPLIT_NO_EMPTY);
+          $hours = preg_split('/\s?[^\s\w:\.]\s?/',$hours, -1, PREG_SPLIT_NO_EMPTY);
           $opens[$key] = date('H:i', strtotime($hours[0]));
           $closes[$key] = $hours[1] ? date('H:i', strtotime($hours[1])): '';
         }


### PR DESCRIPTION
Previously if the hours contained a period the split would fail. Now any of these hour strings should work:

```
5:30 a.m. - 9 p.m.
5:30am - 9pm
5am-9pm
9am - 10pm
5:30 a.m. - 8 p.m. (Member Only Hours: 12 - 8 p.m.)
```

Also removed the extraneous `/d` (digit) selector as it's covered by `/w` (word character)