### PR TITLE
[DS-969] Fix dropdown with open hours information

### DIFF
--- a/js/openy_hours_formatter.js
+++ b/js/openy_hours_formatter.js
@@ -1,9 +1,9 @@
-(function ($) {
+(function ($, once) {
 
   "use strict";
   Drupal.behaviors.openy_hours_formatter = {
     attach: function (context, settings) {
-      $('.today-hours .show-link').once().on('click', function (e) {
+      $(once('today-hours-show-link', '.today-hours .show-link')).on('click', function (e) {
         e.preventDefault();
         $(this)
           .addClass('hidden')
@@ -12,7 +12,7 @@
           .parent()
           .find('.branch-hours').removeClass('hidden');
       });
-      $('.today-hours .hide-link').once().on('click', function (e) {
+      $(once('today-hours-hide-link', '.today-hours .hide-link')).on('click', function (e) {
         e.preventDefault();
         $(this)
           .addClass('hidden')
@@ -113,4 +113,4 @@
     }
 
   };
-})(jQuery);
+})(jQuery, once);

--- a/openy_hours_formatter.libraries.yml
+++ b/openy_hours_formatter.libraries.yml
@@ -1,9 +1,10 @@
 openy_hours_formatter:
-  version: 0.1
+  version: 0.2
   js:
     js/openy_hours_formatter.js: {}
   dependencies:
     - core/jquery
+    - core/once
     - core/drupal
     - core/drupalSettings
     - openy_system/moment


### PR DESCRIPTION
This should be fix this dropdown widget:
![OpenHoursFormatter](https://github.com/open-y-subprojects/openy_hours_formatter/assets/744406/026df6f0-37a1-410d-a35c-f0e03399850b)
