### PR TITLE
Added behavior to apply openy_hours_formatter js for leaflet popup

### DIFF
--- a/js/openy_hours_formatter.js
+++ b/js/openy_hours_formatter.js
@@ -31,7 +31,7 @@
         const observer = new MutationObserver(function (mutations) {
           mutations.forEach(function (mutation) {
             mutation.addedNodes.forEach(function (node) {
-              if (node.nodeType === 1 && node.classList && node.classList.contains('leaflet-popup')) {
+              if (node.nodeType === Node.ELEMENT_NODE && node.classList && node.classList.contains('leaflet-popup')) {
                 Drupal.attachBehaviors(node, settings);
               }
             });

--- a/js/openy_hours_formatter.js
+++ b/js/openy_hours_formatter.js
@@ -24,6 +24,27 @@
     }
   };
 
+  // Applied show/hide today hours functionality for Map.
+  Drupal.behaviors.leafletPopupObserver = {
+    attach: function (context, settings) {
+      $(once('leaflet-observer', 'body', context)).each(function () {
+        const observer = new MutationObserver(function (mutations) {
+          mutations.forEach(function (mutation) {
+            mutation.addedNodes.forEach(function (node) {
+              if (node.nodeType === 1 && node.classList && node.classList.contains('leaflet-popup')) {
+                Drupal.attachBehaviors(node, settings);
+              }
+            });
+          });
+        });
+        
+        observer.observe(document.body, {
+          childList: true,
+          subtree: true
+        });
+      });
+    }
+  };
   Drupal.behaviors.today_hours = {
 
     /**


### PR DESCRIPTION
This problem occurs because Drupal behaviors do not run again when a dynamic element is added to the page (modal window)

To test how it works without patch, we need to click on Location marker and try to click on "All hours". After click it doesn't show hours, it moves to top of the page.  I've added patch that fix this problem